### PR TITLE
block onboarding go back

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_storage/firebase_storage.dart';
@@ -20,6 +19,7 @@ import 'main_page.dart';
 import 'survey_1.dart';
 import 'survey_2.dart';
 
+
 // dart run flutter_native_splash:remove
 // dart run flutter_native_splash:create
 
@@ -27,18 +27,18 @@ void main() async {
   final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding); // 앱이 준비될 때까지 스플래시 화면을 계속 유지하겠다고 선언
 
-  // firebase 관련 초기화
+// firebase 관련 초기화
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
-  // 앱 이니셜라이저 설정
-  // : 기본적으로 Flutter에서 첫 프레임을 그리기 시작할 때 Splash Screen은 제거됨
-  // 만약 앱이 초기화되는 동안에 Splash Screen을 유지하려면 preserve() 또는 remove() 메서드를 같이 사용하면 됨
+// 앱 이니셜라이저 설정
+// : 기본적으로 Flutter에서 첫 프레임을 그리기 시작할 때 Splash Screen은 제거됨
+// 만약 앱이 초기화되는 동안에 Splash Screen을 유지하려면 preserve() 또는 remove() 메서드를 같이 사용하면 됨
 
   final bool isFirstLaunch = await isFirstRun();
-
   FlutterNativeSplash.remove(); // Splash 제거
+
   runApp(MyApp(isFirstLaunch: isFirstLaunch));
 }
 

--- a/lib/services/onboarding_flow.dart
+++ b/lib/services/onboarding_flow.dart
@@ -5,7 +5,7 @@ import '../main_page.dart';
 import '../onboarding_1.dart';
 import '../onboarding_2.dart';
 import '../onboarding_3.dart';
-import 'package:walky/tems_and_cond.dart';
+import 'package:walky/tems_and_cond.dart'; // 약관 페이지로 넘어가기 위해 추가
 
 class OnboardingFlow extends StatefulWidget {
   const OnboardingFlow({super.key});
@@ -28,6 +28,7 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('isFirstRun', false);
     if (!mounted) return;
+    // 온보딩 완료 시 약관 동의 페이지로 이동
     Navigator.of(context).pushReplacement(
       MaterialPageRoute(builder: (_) => const TermsAndConditionPage()),
     );
@@ -43,7 +44,10 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
   Widget build(BuildContext context) {
     final isLast = index == pages.length - 1;
 
-    return Scaffold(
+    // 뒤로가기 차단을 위해 PopScope 위젯 추가
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
       backgroundColor: Colors.white,
       body: SafeArea(
         child: Padding(
@@ -53,7 +57,7 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
               Expanded(
                 child: PageView(
                   controller: controller,
-                  // ✅ 스와이프 가능: physics 제거 (기본 스크롤)
+                  //  스와이프 가능: physics 제거 (기본 스크롤)
                   onPageChanged: (i) => setState(() => index = i),
                   children: pages,
                 ),
@@ -62,7 +66,7 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
               _DotsIndicator(length: pages.length, current: index),
               const SizedBox(height: 16),
 
-              // ✅ 마지막 페이지만 버튼 보이기 (애니메이션 포함)
+              //  마지막 페이지만 버튼 보이기 (애니메이션 포함)
               AnimatedSwitcher(
                 duration: const Duration(milliseconds: 220),
                 switchInCurve: Curves.easeOut,
@@ -87,9 +91,10 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
                   // 버튼 영역과 동일한 높이로 레이아웃 유지
                   key: ValueKey('placeholder'),
                   height: 52,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/survey_1.dart
+++ b/lib/survey_1.dart
@@ -19,109 +19,111 @@ class _Survey1State extends State<Survey1> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      body: Stack(
-        children: [
-          Positioned(
-              top: 54.0,
-              left: 41.0,
-              right: 41.0,
-              child: ClipRRect(
-                borderRadius: BorderRadius.all(Radius.circular(15)),
-                child: LinearProgressIndicator(
-                  value: 0.167,
-                  minHeight: 10.0,
-                  backgroundColor: Color(0xFFF5F5F5),
-                  valueColor: const AlwaysStoppedAnimation<Color>(
-                    Color(0xFFBFE240),
-                  ),
-                ),
-              )
-          ),
-
-          // 2. 텍스트와 입력 필드
-          Positioned(
-            top: 120.0,
-            left: 20.0,
-            right: 20.0,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const SizedBox(height: 30),
-                const Text(
-                  'STEP 1',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                    color: Color(0xFF707070),
-                  ),
-                ),
-                const SizedBox(height: 10),
-                const Text(
-                  '닉네임을 설정해주세요',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Color(0xFF000000),
-                  ),
-                ),
-                const SizedBox(height: 30),
-                TextField(
-                  controller: _nicknameController,
-                  decoration: InputDecoration(
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(50.0),
-                      borderSide: BorderSide(color: Color(0xFFDDD7D7)),
+    return PopScope(
+        child: Scaffold(
+          backgroundColor: Colors.white,
+          body: Stack(
+            children: [
+              Positioned(
+                  top: 54.0,
+                  left: 41.0,
+                  right: 41.0,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.all(Radius.circular(15)),
+                    child: LinearProgressIndicator(
+                      value: 0.167,
+                      minHeight: 10.0,
+                      backgroundColor: Color(0xFFF5F5F5),
+                      valueColor: const AlwaysStoppedAnimation<Color>(
+                        Color(0xFFBFE240),
+                      ),
                     ),
-                    enabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(50.0),
-                      borderSide: BorderSide(color: Color(0xFFDDD7D7)),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(50.0),
-                      borderSide: BorderSide(color: Color(0xFFDDD7D7)),
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Center(
-                  child: const Text(
-                    '한글 또는 영문만 사용하여 2~12자로 입력해주세요.',
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Colors.grey,
-                    ),
-                  ),
-                )
-              ],
-            ),
-          ),
-
-          // 3. 다음 단계 버튼
-          Positioned(
-            top: MediaQuery.of(context).size.height * 0.85,
-            right: MediaQuery.of(context).size.width * 0.10,
-            child: FloatingActionButton(
-              onPressed: () {
-                // ✨ 버튼을 누르면 다음 화면(Survey2)으로 이동하는 로직입니다.
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const Survey2(),
-                  ),
-                );
-              },
-              child: const Icon(
-                Icons.arrow_forward,
-                color: Colors.white,
+                  )
               ),
-              backgroundColor: Color(0xFFBFE240),
-              shape: const CircleBorder(),
-            ),
+
+              // 2. 텍스트와 입력 필드
+              Positioned(
+                top: 120.0,
+                left: 20.0,
+                right: 20.0,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 30),
+                    const Text(
+                      'STEP 1',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF707070),
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    const Text(
+                      '닉네임을 설정해주세요',
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF000000),
+                      ),
+                    ),
+                    const SizedBox(height: 30),
+                    TextField(
+                      controller: _nicknameController,
+                      decoration: InputDecoration(
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(50.0),
+                          borderSide: BorderSide(color: Color(0xFFDDD7D7)),
+                        ),
+                        enabledBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(50.0),
+                          borderSide: BorderSide(color: Color(0xFFDDD7D7)),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(50.0),
+                          borderSide: BorderSide(color: Color(0xFFDDD7D7)),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Center(
+                      child: const Text(
+                        '한글 또는 영문만 사용하여 2~12자로 입력해주세요.',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Colors.grey,
+                        ),
+                      ),
+                    )
+                  ],
+                ),
+              ),
+
+              // 3. 다음 단계 버튼
+              Positioned(
+                top: MediaQuery.of(context).size.height * 0.85,
+                right: MediaQuery.of(context).size.width * 0.10,
+                child: FloatingActionButton(
+                  onPressed: () {
+                    // ✨ 버튼을 누르면 다음 화면(Survey2)으로 이동하는 로직입니다.
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const Survey2(),
+                      ),
+                    );
+                  },
+                  child: const Icon(
+                    Icons.arrow_forward,
+                    color: Colors.white,
+                  ),
+                  backgroundColor: Color(0xFFBFE240),
+                  shape: const CircleBorder(),
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
+        ),
     );
   }
 }

--- a/lib/survey_2.dart
+++ b/lib/survey_2.dart
@@ -37,141 +37,143 @@ class _Survey2State extends State<Survey2> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      body: Stack(
-        children: [
-          Positioned(
-            top: 54.0,
-            left: 41.0,
-            right: 41.0,
-            child: ClipRRect(
-              borderRadius: const BorderRadius.all(Radius.circular(15)),
-              child: LinearProgressIndicator(
-                value: 0.334,
-                minHeight: 10.0,
-                backgroundColor: const Color(0xFFF5F5F5),
-                valueColor: const AlwaysStoppedAnimation<Color>(
-                  Color(0xFFBFE240),
+    return PopScope(
+        child: Scaffold(
+          backgroundColor: Colors.white,
+          body: Stack(
+            children: [
+              Positioned(
+                top: 54.0,
+                left: 41.0,
+                right: 41.0,
+                child: ClipRRect(
+                  borderRadius: const BorderRadius.all(Radius.circular(15)),
+                  child: LinearProgressIndicator(
+                    value: 0.334,
+                    minHeight: 10.0,
+                    backgroundColor: const Color(0xFFF5F5F5),
+                    valueColor: const AlwaysStoppedAnimation<Color>(
+                      Color(0xFFBFE240),
+                    ),
+                  ),
                 ),
               ),
-            ),
-          ),
-          Positioned(
-            top: 120.0,
-            left: 20.0,
-            right: 20.0,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: const [
-                SizedBox(height: 30),
-                Text(
-                  'STEP 2',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                    color: Color(0xFF707070),
-                  ),
+              Positioned(
+                top: 120.0,
+                left: 20.0,
+                right: 20.0,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: const [
+                    SizedBox(height: 30),
+                    Text(
+                      'STEP 2',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF707070),
+                      ),
+                    ),
+                    SizedBox(height: 10),
+                    Text(
+                      '캐릭터를 골라보세요',
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF000000),
+                      ),
+                    ),
+                  ],
                 ),
-                SizedBox(height: 10),
-                Text(
-                  '캐릭터를 골라보세요',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Color(0xFF000000),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Center(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 50.0),
-              child: GridView.count(
-                crossAxisCount: 2,
-                crossAxisSpacing: 10.0,
-                mainAxisSpacing: 25.0, // 상자와 텍스트를 포함한 전체 위젯 간의 수직 간격
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                children: List.generate(4, (index) {
-                  return GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        _selectedIndex = index;
-                      });
-                    },
-                    // ✨ 상자와 텍스트를 별도의 Column으로 묶었습니다.
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Expanded( // 상자가 남은 공간을 차지하도록 Expanded 추가
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              border: Border.all(
-                                color: _selectedIndex == index
-                                    ? Colors.blue
-                                    : Colors.grey[300]!,
-                                width: 3.0,
-                              ),
-                              borderRadius: BorderRadius.circular(20.0),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Colors.black.withOpacity(0.1),
-                                  blurRadius: 10,
-                                  offset: const Offset(0, 5),
+              ),
+              Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 50.0),
+                  child: GridView.count(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 10.0,
+                    mainAxisSpacing: 25.0, // 상자와 텍스트를 포함한 전체 위젯 간의 수직 간격
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    children: List.generate(4, (index) {
+                      return GestureDetector(
+                        onTap: () {
+                          setState(() {
+                            _selectedIndex = index;
+                          });
+                        },
+                        // ✨ 상자와 텍스트를 별도의 Column으로 묶었습니다.
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Expanded( // 상자가 남은 공간을 차지하도록 Expanded 추가
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.white,
+                                  border: Border.all(
+                                    color: _selectedIndex == index
+                                        ? Colors.blue
+                                        : Colors.grey[300]!,
+                                    width: 3.0,
+                                  ),
+                                  borderRadius: BorderRadius.circular(20.0),
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: Colors.black.withOpacity(0.1),
+                                      blurRadius: 10,
+                                      offset: const Offset(0, 5),
+                                    ),
+                                  ],
                                 ),
-                              ],
+                                child: Padding(
+                                  padding: const EdgeInsets.all(12.0),
+                                  child: Image.asset(_characterImages[index]),
+                                ),
+                              ),
                             ),
-                            child: Padding(
-                              padding: const EdgeInsets.all(12.0),
-                              child: Image.asset(_characterImages[index]),
+                            const SizedBox(height: 10), // 상자와 텍스트 사이 간격
+                            Text(
+                              _characterNames[index], // ✨ 상자 바깥에 텍스트를 배치
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.black,
+                              ),
                             ),
-                          ),
+                          ],
                         ),
-                        const SizedBox(height: 10), // 상자와 텍스트 사이 간격
-                        Text(
-                          _characterNames[index], // ✨ 상자 바깥에 텍스트를 배치
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                            color: Colors.black,
-                          ),
+                      );
+                    }),
+                  ),
+                ),
+              ),
+              Positioned(
+                top: MediaQuery.of(context).size.height * 0.85,
+                right: MediaQuery.of(context).size.width * 0.10,
+                child: FloatingActionButton(
+                  onPressed: () {
+                    if (_selectedIndex != null) {
+                      _saveSelectionToDatabase(_selectedIndex!);
+                    } else {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('캐릭터를 선택해주세요.'),
+                          duration: Duration(seconds: 2),
                         ),
-                      ],
-                    ),
-                  );
-                }),
+                      );
+                    }
+                  },
+                  child: const Icon(
+                    Icons.arrow_forward,
+                    color: Colors.white,
+                  ),
+                  backgroundColor: const Color(0xFFBFE240),
+                  shape: const CircleBorder(),
+                ),
               ),
-            ),
+            ],
           ),
-          Positioned(
-            top: MediaQuery.of(context).size.height * 0.85,
-            right: MediaQuery.of(context).size.width * 0.10,
-            child: FloatingActionButton(
-              onPressed: () {
-                if (_selectedIndex != null) {
-                  _saveSelectionToDatabase(_selectedIndex!);
-                } else {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('캐릭터를 선택해주세요.'),
-                      duration: Duration(seconds: 2),
-                    ),
-                  );
-                }
-              },
-              child: const Icon(
-                Icons.arrow_forward,
-                color: Colors.white,
-              ),
-              backgroundColor: const Color(0xFFBFE240),
-              shape: const CircleBorder(),
-            ),
-          ),
-        ],
-      ),
+        ),
     );
   }
 }

--- a/lib/tems_and_cond.dart
+++ b/lib/tems_and_cond.dart
@@ -40,116 +40,113 @@ class _TermsAndConditionsPageState extends State<TermsAndConditionPage> {
   Widget build(BuildContext context) {
     final bool canProceed = _requiredAgreements.every((element) => element);
 
-    return Scaffold(
-      backgroundColor: Colors.white,
-      appBar: AppBar(
-        title: const Text('회원가입 약관'),
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
         backgroundColor: Colors.white,
-        elevation: 0,
-        foregroundColor: Colors.black,
-      ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Text(
-                '약관동의',
-                style: TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.black87,
-                ),
-              ),
-              const SizedBox(height: 8),
-              const Text(
-                '편리한 서비스 이용을 위해 약관에 동의해주세요.',
-                style: TextStyle(
-                  fontSize: 14,
-                  color: Colors.black54,
-                ),
-              ),
-              const SizedBox(height: 32),
-              Container(
-                decoration: BoxDecoration(
-                  border: Border.all(color: Colors.grey.shade400),
-                  borderRadius: BorderRadius.circular(50),
-                ),
-                child: _buildAgreementItem(
-                  title: '전체 동의하기',
-                  value: _isAllAgreed,
-                  onChanged: _onToggleAll,
-                  isBold: true,
-                  onTap: null,
-                ),
-              ),
-              _buildAgreementItem(
-                title: '(필수) 서비스 이용 약관',
-                value: _requiredAgreements[0],
-                onChanged: (v) => _onToggleRequired(0, v),
-                onTap: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const FullDoc1()),
-                  );
-                },
-              ),
-              _buildAgreementItem(
-                title: '(필수) 개인정보 수집 동의',
-                value: _requiredAgreements[1],
-                onChanged: (v) => _onToggleRequired(1, v),
-                onTap: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const FullDoc2()),
-                  );
-                },
-              ),
-              _buildAgreementItem(
-                title: '(필수) 위치정보 이용 동의',
-                value: _requiredAgreements[2],
-                onChanged: (v) => _onToggleRequired(2, v),
-                onTap: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const FullDoc3()),
-                  );
-                },
-              ),
-              const Spacer(),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton(
-                  style: FilledButton.styleFrom(
-                    backgroundColor: canProceed
-                        ? const Color(0xFFBFE240)
-                        : Colors.grey.shade300,
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                    shape: RoundedRectangleBorder(
+          body: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '약관동의',
+                    style: TextStyle(
+                      fontSize: 30,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.black87,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    '편리한 서비스 이용을 위해 약관에 동의해주세요.',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Colors.black54,
+                    ),
+                  ),
+                  const SizedBox(height: 45),
+                  Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey.shade400),
                       borderRadius: BorderRadius.circular(50),
                     ),
-                  ),
-                  onPressed: canProceed
-                      ? () {
-                    // ✅ '동의' 버튼 클릭 시 servey_1.dart로 이동
-                    Navigator.of(context).pushReplacement(
-                      MaterialPageRoute(builder: (_) => const Survey1()),
-                    );
-                  }
-                      : null,
-                  child: const Text(
-                    '동의',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.black,
+                    child: _buildAgreementItem(
+                      title: '전체 동의하기',
+                      value: _isAllAgreed,
+                      onChanged: _onToggleAll,
+                      isBold: true,
+                      onTap: null,
                     ),
                   ),
-                ),
+                  _buildAgreementItem(
+                    title: '(필수) 서비스 이용 약관',
+                    value: _requiredAgreements[0],
+                    onChanged: (v) => _onToggleRequired(0, v),
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(builder: (_) => const FullDoc1()),
+                      );
+                    },
+                  ),
+                  _buildAgreementItem(
+                    title: '(필수) 개인정보 수집 동의',
+                    value: _requiredAgreements[1],
+                    onChanged: (v) => _onToggleRequired(1, v),
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(builder: (_) => const FullDoc2()),
+                      );
+                    },
+                  ),
+                  _buildAgreementItem(
+                    title: '(필수) 위치정보 이용 동의',
+                    value: _requiredAgreements[2],
+                    onChanged: (v) => _onToggleRequired(2, v),
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(builder: (_) => const FullDoc3()),
+                      );
+                    },
+                  ),
+                  const Spacer(),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      style: FilledButton.styleFrom(
+                        backgroundColor: canProceed
+                            ? const Color(0xFFBFE240)
+                            : Colors.grey.shade300,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(50),
+                        ),
+                      ),
+                      onPressed: canProceed
+                          ? () {
+                        //  '동의' 버튼 클릭 시 servey_1.dart로 이동
+                        Navigator.of(context).pushReplacement(
+                          MaterialPageRoute(builder: (_) => const Survey1()),
+                        );
+                      }
+                          : null,
+                      child: const Text(
+                        '동의',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.black,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
-      ),
-    );
+      );
   }
 
   Widget _buildAgreementItem({
@@ -175,7 +172,7 @@ class _TermsAndConditionsPageState extends State<TermsAndConditionPage> {
             Text(
               title,
               style: TextStyle(
-                fontSize: 20,
+                fontSize: 18,
                 fontWeight: isBold ? FontWeight.bold : FontWeight.normal,
                 color: isBold ? Colors.black87 : Colors.black54,
               ),


### PR DESCRIPTION
UX 문제점 : 온보딩(온보딩 + 약관동의 + 설문조사 등의 처음 앱 다운로더가 겪는 플로우 전체를 의미) 과정에서 사용자가 중간에 앱을 나가면 이미 앱을 사용하고 있는 사용자라고 판단을 해서 아직 온보딩 과정을 모두 거치지도 않고 가입도 안했는데 스플래시 이후에 메인 화면이 뜸

이에 대한 임시방편으로 온보딩 과정 중에 있는 onboarding_flow.dart, terms_and_cond.dart, survey_1.dart, survey_2.dart의 Scaffold를 PopScope로 감싸 canPop : false로 뒤로가기를 강제 차단해놓음